### PR TITLE
Toggling folders now works just like in Windows Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Here i will just list a few snippets / examples that you can use
 
 [![Folder browser](./doc/folderBrowser.PNG)]()
 
-This part should be pretty intuitive. By clicking on folder you open/close it. But also it displays all of the bookmarks that are located inside it (no matter how deep, in my case it will also display children of _WebDesignSites_ folder in my case) on the main section of the screen right of the sidenav.
+This part should be pretty intuitive. It works exactly like Windows Explorer. By clicking on arrow or double clicking on folder you open/close it, and if you click once on a folder you will see its content without toggling it, which is all of the bookmarks that are located inside it (no matter how deep, in my case it will also display children of _WebDesignSites_ folder).
 
-To help guide you visually folders with **purple** color will contain dynamic / tracked bookmarks which are, as we saw previously filled with **red** color.
+To help guide you visually, folders with **purple** color will contain dynamic / tracked bookmarks which are, as we saw previously filled with **red** color.
 
 Clicking on the folder also selects it, which lets you add/edit/delete it as we will see later, same goes for clicking on bookmark.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-dynamic-bookmarks",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Updates bookmarks dynamically based on given regExp",
   "scripts": {
     "dev": "webpack --mode development",

--- a/src/css/treeView.css
+++ b/src/css/treeView.css
@@ -7,6 +7,10 @@
   overflow: auto;
   white-space: nowrap;
 }
+#treeView * {
+  user-select: none;
+  -webkit-user-select: none;
+}
 #treeView span {
   display: inline-flex;
   vertical-align: middle;

--- a/src/js/bookmarkManager/treeViewComponents.js
+++ b/src/js/bookmarkManager/treeViewComponents.js
@@ -56,7 +56,15 @@ export function handleFolderHeaderClick(event) {
     : event.target.parentElement;
   const folder = folderHeader.parentElement;
   const opened = folderHeader.getAttribute('opened') == 'true';
-  const newOpened = !opened;
+  let newOpened = opened;
+
+  if (event.type == 'click') {
+    newOpened = event.target.classList.contains('arrow-icon')
+      ? !opened
+      : opened;
+  } else if (event.type == 'dblclick') {
+    newOpened = !opened;
+  }
 
   let icons = folderHeader.querySelectorAll('.material-icons');
   icons.forEach((icon) => {

--- a/src/js/components/Folder.js
+++ b/src/js/components/Folder.js
@@ -21,6 +21,7 @@ const Folder = (
     header(
       {
         onClick: onClick,
+        onDblclick: onClick,
         className: 'folder-header hoverable',
         opened: opened
       },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Dynamic Bookmarks",
   "description": "Updates bookmarks dynamically based on given regExp",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "permissions": ["tabs", "bookmarks", "storage"],
   "background": {
     "page": "background.html"


### PR DESCRIPTION
Made folder navigation in tree view work just like in Windows Explorer so users are more familiar to it.

By clicking on arrow or double clicking on folder you open/close it, and if you click once on a folder you will see its content without toggling it, which is all of the bookmarks that are located inside it (no matter how deep, in my case it will also display children of _WebDesignSites_ folder).