### PR TITLE
v2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Lets start off by clicking on the extension icon on top right. <br>
 Here we need to enter a name of the bookmark we wish to create,
 and a regular expression (regExp) based on which our bookmark will be updated. <br />
 
+> Note: Since v2.4.0 regExp is automatically generated / suggested.
+
 But WHAT is a **regular expression**? It simply **is a sequence of characters that define a search pattern**. Ever did CTRL+F to find something on page? Well it's preety much the same thing, but with extra special characters that let your search be more flexible.
 
 Once the form is submited a dynamic bookmark will be created inside `Other bookmarks` folder.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-dynamic-bookmarks",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Chrome extension which dynamically updates bookmarks based on the specified regular expression.",
   "scripts": {
     "dev": "webpack --mode development",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-dynamic-bookmarks",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Chrome extension which dynamically updates bookmarks based on the specified regular expression.",
   "scripts": {
     "dev": "webpack --mode development",

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -1,5 +1,6 @@
 #popup-form {
   min-width: 320px;
-  min-height: 200px;
+  min-height: 260px;
   padding-right: 2em;
+  padding-bottom: 1em;
 }

--- a/src/js/bookmarkManager/folderInfo.js
+++ b/src/js/bookmarkManager/folderInfo.js
@@ -125,7 +125,7 @@ function createFolderInfoChild(
   let hostName = url.match(/^(http[s]?:\/\/.*?\/)/i);
   let faviconLink;
   if (hostName) {
-    hostName = hostName[0].replace(/http[s]:\/\//, '');
+    hostName = hostName[0].replace(/http[s]?:\/\//, '');
     faviconLink = 'https://www.google.com/s2/favicons?domain=' + hostName;
   } else {
     // i used this instead of ../images/ because default_favicon is located

--- a/src/js/bookmarkManager/selectHandler.js
+++ b/src/js/bookmarkManager/selectHandler.js
@@ -39,7 +39,11 @@ class SelectHandler {
             console.warn(chrome.runtime.lastError.message);
           } else {
             openAllParentFolders(bookmarks[0].parentId);
-            window.location = '#' + id;
+            element.scrollIntoView({
+              behavior: 'smooth',
+              block: 'center',
+              inline: 'nearest'
+            });
           }
         });
       }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Dynamic Bookmarks",
   "description": "Chrome extension which dynamically updates bookmarks based on the specified regular expression.",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "permissions": ["tabs", "bookmarks", "storage"],
   "background": {
     "page": "background.html"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Dynamic Bookmarks",
   "description": "Chrome extension which dynamically updates bookmarks based on the specified regular expression.",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "permissions": ["tabs", "bookmarks", "storage"],
   "background": {
     "page": "background.html"

--- a/src/popup.html
+++ b/src/popup.html
@@ -17,6 +17,12 @@
       </div>
 
       <div class="input-field">
+        <label for="url-input">Url: </label>
+        <input type="url" class="validate" id="url-input" name="url" required>
+        <span class="helper-text" data-error="url must be in form http[s]://..."></span>
+      </div>
+
+      <div class="input-field">
         <label for="regexp-input">RegExp: </label>
         <input type="text" id="regexp-input" name="regexp" required>
       </div>


### PR DESCRIPTION
Changes in popup:
- additional field _url_ added
- `regExp` field is now automatically filled once popup is opened with suggested value (ex. for youtube url with `list=...`. it will suggest regExp which would  track given yt playlist. 
On other sites like 
`https://learn.freecodecamp.org/responsive-web-design/basic-html-and-html5/say-hello-to-html-elements` 
it will replace part after last '/' with '.*' , in this case it would be: 
`learn.freecodecamp.org/responsive-web-design/basic-html-and-html5/.*` )