### PR TITLE
v2.4.1 - fixed yt playlist regexp popup suggestion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-dynamic-bookmarks",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Chrome extension which dynamically updates bookmarks based on the specified regular expression.",
   "scripts": {
     "dev": "webpack --mode development",

--- a/src/js/popup/index.js
+++ b/src/js/popup/index.js
@@ -28,14 +28,17 @@ document.addEventListener('DOMContentLoaded', function() {
       if (urlInput) {
         urlInput.value = url;
       }
-      if (/youtube\.com\/.*list=\w+/.test(url)) {
-        const regExpString = url.match(/list=\w+/i);
-        regExpInput.value = `youtube\.com\/.*${regExpString}`;
+      if (/youtube\.com\/.*list=[a-z0-9-]+/i.test(url)) {
+        const regExpString = url.match(/list=[a-z0-9-]+/i);
+        regExpInput.value = `youtube\\.com/.*${regExpString}`;
       } else {
         const subUrl = url.match(/^(http[s]?:\/\/)?(.*\/)|(.*$)/);
         if (subUrl) {
-          const regExpString = subUrl[0].replace(/http[s]?:\/\/(www\.)?/, '');
-          regExpInput.value = `${regExpString.replace(/[.]/g, `\.`)}.*`;
+          const regExpString = subUrl[0].replace(
+            /^(http[s]?:\/\/)?(www\.)?/,
+            ''
+          );
+          regExpInput.value = `${regExpString.replace(/\./g, `\\.`)}.*`;
         }
       }
       M.updateTextFields();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Dynamic Bookmarks",
   "description": "Chrome extension which dynamically updates bookmarks based on the specified regular expression.",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "permissions": ["tabs", "bookmarks", "storage"],
   "background": {
     "page": "background.html"


### PR DESCRIPTION
- fixed regExp suggestion on url with youtube domain name and `list=...` 
- dots - `.` in url are now replaced with `\.` in regExp suggestion (ex. `youtube.com` is replaced with `youtube\.com`)