### PR TITLE
feat: automate extension release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,6 +47,18 @@ jobs:
         if: steps.tag_check.outputs.exists == 'false'
         run: yarn install --frozen-lockfile
 
+      - name: Lint
+        if: steps.tag_check.outputs.exists == 'false'
+        run: yarn lint
+
+      - name: Type check
+        if: steps.tag_check.outputs.exists == 'false'
+        run: yarn check:types
+
+      - name: Test
+        if: steps.tag_check.outputs.exists == 'false'
+        run: yarn test
+
       - name: Build
         if: steps.tag_check.outputs.exists == 'false'
         run: yarn build
@@ -56,16 +70,6 @@ jobs:
           zip -r ../extension-v${{ steps.package_version.outputs.version }}.zip .
           cd ..
 
-      - name: Create GitHub Release
-        if: steps.tag_check.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ steps.package_version.outputs.version }}
-          files: extension-v${{ steps.package_version.outputs.version }}.zip
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Upload to Chrome Web Store
         if: steps.tag_check.outputs.exists == 'false'
         uses: mnao305/chrome-extension-upload@v5.0.0
@@ -76,3 +80,13 @@ jobs:
           client-secret: ${{ secrets.CLIENT_SECRET }}
           refresh-token: ${{ secrets.REFRESH_TOKEN }}
           publish: true
+
+      - name: Create GitHub Release
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.package_version.outputs.version }}
+          files: extension-v${{ steps.package_version.outputs.version }}.zip
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release Extension
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from package.json
+        id: package_version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: tag_check
+        run: |
+          TAG_NAME="v${{ steps.package_version.outputs.version }}"
+          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Tag $TAG_NAME already exists. Skipping release."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup Node.js
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: yarn
+
+      - name: Enable Yarn (packageManager in package.json)
+        if: steps.tag_check.outputs.exists == 'false'
+        run: corepack enable && corepack prepare yarn@1.22.22 --activate
+
+      - name: Install dependencies
+        if: steps.tag_check.outputs.exists == 'false'
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        if: steps.tag_check.outputs.exists == 'false'
+        run: yarn build
+
+      - name: Zip extension
+        if: steps.tag_check.outputs.exists == 'false'
+        run: |
+          cd build
+          zip -r ../extension-v${{ steps.package_version.outputs.version }}.zip .
+          cd ..
+
+      - name: Create GitHub Release
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.package_version.outputs.version }}
+          files: extension-v${{ steps.package_version.outputs.version }}.zip
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload to Chrome Web Store
+        if: steps.tag_check.outputs.exists == 'false'
+        uses: mnao305/chrome-extension-upload@v5.0.0
+        with:
+          file-path: extension-v${{ steps.package_version.outputs.version }}.zip
+          extension-id: ${{ secrets.EXTENSION_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
+          client-secret: ${{ secrets.CLIENT_SECRET }}
+          refresh-token: ${{ secrets.REFRESH_TOKEN }}
+          publish: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR introduces an automated release workflow using GitHub Actions.

### Key Changes
- Added `.github/workflows/release.yml`.
- Workflow triggers on pushes to `master`.
- Automatically runs linting, type-checking, and tests before release.
- Uploads to Chrome Web Store **before** creating a GitHub release to ensure a robust retry mechanism.
- Includes `permissions: contents: write` to allow release creation.

### Setup Required
Please ensure the following GitHub Secrets are configured in the repository:
- `EXTENSION_ID`
- `CLIENT_ID`
- `CLIENT_SECRET`
- `REFRESH_TOKEN`