### PR TITLE
chore: bump version to 3.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chrome-dynamic-bookmarks",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "packageManager": "yarn@1.22.22",
   "description": "Chrome extension which dynamically updates bookmarks based on the specified regular expression.",
   "pre-commit": [


### PR DESCRIPTION
Bumping version to 3.1.4. Once merged to master, this will trigger the first automated release to the Chrome Web Store and GitHub.