### PR TITLE
chore: clean up CI and release workflows

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,15 +5,10 @@ on:
   pull_request:
     branches: [master, dev]
   workflow_dispatch:
-    inputs:
-      run_e2e:
-        description: "Run Playwright extension e2e tests"
-        required: false
-        default: false
-        type: boolean
+
 jobs:
   build:
-    name: Test
+    name: Build & Checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,24 +23,9 @@ jobs:
       - run: yarn check:types
       - run: yarn build
       - run: yarn test --coverage --runInBand
+
   e2e:
-    name: E2E (manual)
-    if: github.event_name == 'workflow_dispatch' && inputs.run_e2e == true
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: yarn
-      - name: Enable Yarn (packageManager in package.json)
-        run: corepack enable && corepack prepare yarn@1.22.22 --activate
-      - run: yarn install --frozen-lockfile
-      - run: yarn build
-      - run: npx playwright install --with-deps chromium
-      - run: yarn test:e2e
-  e2e-on-risky-paths:
-    name: E2E (path gated)
+    name: E2E
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 name: Release Extension
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
     branches:
       - master
 
@@ -11,6 +14,7 @@ concurrency:
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This PR cleans up the CI and release workflows as requested:
- Removed manual E2E job from CI (`node.js.yml`).
- Renamed CI jobs: `Test` -> `Build & Checks`, `E2E (path gated)` -> `E2E`.
- Linked `release.yml` to wait for the `CI` workflow to complete successfully on the `master` branch before starting.
- Added a safety check to the release job to ensure it only runs if the CI conclusion was `success`.