### PR TITLE
Harden CI/release workflow guards

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,10 +6,14 @@ on:
     branches: [master, dev]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build & Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -28,6 +32,7 @@ jobs:
     name: E2E
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -35,11 +40,19 @@ jobs:
         with:
           filters: |
             e2e:
+              - 'e2e/**'
+              - 'playwright.config.js'
+              - 'package.json'
+              - 'yarn.lock'
+              - 'vite.config.ts'
+              - 'manifest.config.ts'
+              - 'public/**'
               - 'src/background/**'
               - 'src/shared/lib/browser/**'
               - 'src/shared/store/**'
               - 'src/popup/**'
               - 'src/bookmarkManager/**'
+              - 'src/options/**'
       - uses: actions/setup-node@v4
         if: steps.changes.outputs.e2e == 'true'
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,20 @@ concurrency:
 
 jobs:
   release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'master'
+      }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Get version from package.json


### PR DESCRIPTION
## Summary
- tighten release gating to only run after successful `push` CI runs on `master`
- build releases from the exact validated commit SHA from the triggering CI run
- improve CI safety with explicit read permissions, job timeouts, and broader E2E path filters

## Test plan
- [x] Validate workflow YAML syntax parses locally
- [x] Verify CI runs on PR and E2E path filter behavior is correct
- [x] Merge to `master` and confirm release runs only from successful `push` CI

Made with [Cursor](https://cursor.com)